### PR TITLE
Skip duplicate workflow runs to shorten list of checks

### DIFF
--- a/.github/workflows/latex-three-os.yml
+++ b/.github/workflows/latex-three-os.yml
@@ -1,9 +1,15 @@
 name: Test LaTeX
 
-on: 
-  - push
-  - pull_request
-  - workflow_dispatch
+on:
+  # If you specify activity types or filters for an event and your workflow
+  # triggers on multiple events, ... You must append a colon (:) to all events,
+  # including events without configuration.
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-activity-types-and-filters-with-multiple-events
+  push:
+    branches-ignore:
+      - 'skip*' # just a tempt test
+  pull_request:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    if: false
+    # if: false
     name: Hello world action
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With setting `on: [push, pull_request]`, pushing to a branch that plays the role of the base branch of an opened PR triggers the workflow twice.  Further, if the head and base branches of such PR are in a same repo, both set of workflow runs are shown in the list of checks, which doubles the length of list, see for example #6, commit 31b6c2b
![image](https://user-images.githubusercontent.com/6376638/226443871-043f6e6e-cd27-4e20-9a2d-6c940e17fad7.png)

The original goal is to not show such duplicate.  This quickly turns into the need to skip duplicate actions.  If the head branch has no commits behind the base branch, unless special conditions are set, the workflow runs triggered by even `push` and `pull_request` are the same, hence should be skippable.

A good solution should totally skip duplicate runs, by adding checks using workflow syntax `if: <expression>`.  If that's impossible, action [`fkirc/skip-duplicate-actions`](https://github.com/fkirc/skip-duplicate-actions) (found in [comment to discussion #26276](https://github.com/orgs/community/discussions/26276#discussioncomment-3251146)) provides a last resort to still run the workflow but skip its main body if a quick check is passed.

Relevant doc pages
- Events that trigger workflows https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
- Web events and payloads - event `pull_request` type `synchronize` https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request

---
Concepts: head branch vs base branch

> When thinking about branches, remember that the base branch is **where** changes should be applied, the head branch contains **what** you would like to be applied.
> https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request#changing-the-branch-range-and-destination-repository