### PR TITLE
Does `on.merge_group` support `branches-ignore` filter

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,6 +6,9 @@ on:
         - 'self/**' # "**"" also matches remaining "/"
     pull_request:
     workflow_dispatch:
+    merge_group:
+      branches:
+        - 'self/**'
 
 jobs:
   test:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,7 +7,7 @@ on:
     pull_request:
     workflow_dispatch:
     merge_group:
-      branches:
+      branches-x:
         - 'self/**'
 
 jobs:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,9 +5,9 @@ on:
       branches-ignore:
         - 'self/**' # "**"" also matches remaining "/"
     pull_request:
-      branches-x:
-        - 'invalid filter name'
     workflow_dispatch:
+      non-existeng-filter:
+        - 'what'
     merge_group:
       branches-x:
         - 'self/**'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,6 +4,8 @@ on:
     push:
       branches-ignore:
         - 'self/**' # "**"" also matches remaining "/"
+      branches-x:
+        - 'invalid filter name'
     pull_request:
     workflow_dispatch:
     merge_group:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,9 +4,9 @@ on:
     push:
       branches-ignore:
         - 'self/**' # "**"" also matches remaining "/"
+    pull_request:
       branches-x:
         - 'invalid filter name'
-    pull_request:
     workflow_dispatch:
     merge_group:
       branches-x:


### PR DESCRIPTION
If the merged
- `https://github.com/actions/languageservices/pull/12` Add branches to merge-group schema

missed to add a `branches-ignore` filter as well.

More info
- Filter `branches` is definitely supported since it's used in the official blog for merge group: https://github.blog/changelog/2022-08-18-merge-group-webhook-event-and-github-actions-workflow-trigger/.
- At the time of writing this, `on.merge_group.branches` is not documented.
  - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
  - Search for "branches|" ("|" is a vertical bar) on https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions

