### PR TITLE
Test unzip in powershell

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: A workflow for my Hello World file
+name: Unzip in powershell
 on: 
   push:
     branches-ignore:
@@ -11,11 +11,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Hello world action
-    runs-on: ubuntu-latest
+  build-windows:
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./action-a
-        with:
-          MY_NAME: "Mona"
+
+      - name: Install Noto fonts
+        run: |
+          Invoke-WebRequest -Uri ${{ env.NOTO_SANS_URL }}  -OutFile NotoSansCJK-OTC.zip
+          Invoke-WebRequest -Uri ${{ env.NOTO_SERIF_URL }} -OutFile NotoSerifCJK-OTC.zip
+          Get-ChildItem "*.zip"
+          unzip -ojd C:\Windows\Fonts\ "*OTC.zip" "*.ttc"
+        env:
+          NOTO_SANS_URL: https://github.com/googlefonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
+          NOTO_SERIF_URL: https://github.com/googlefonts/noto-cjk/releases/download/Serif2.001/04_NotoSerifCJKOTC.zip


### PR DESCRIPTION
https://github.com/muzimuzhi/ctex-kit/actions/runs/6905979770/job/18789951994

Why
```yaml
    - name: Install Noto fonts
      run: |
        Invoke-WebRequest -Uri ${{ env.NOTO_SANS_URL }}  -OutFile NotoSansCJK-OTC.zip
        Invoke-WebRequest -Uri ${{ env.NOTO_SERIF_URL }} -OutFile NotoSerifCJK-OTC.zip
        Get-ChildItem "*.zip"
        unzip -ojd C:\Windows\Fonts\ "*OTC.zip" "*.ttc"
```
failed as
```
Directory: D:\a\ctex-kit\ctex-kit

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          11/[17](https://github.com/muzimuzhi/ctex-kit/actions/runs/6905979770/job/18789951994#step:4:18)/[20](https://github.com/muzimuzhi/ctex-kit/actions/runs/6905979770/job/18789951994#step:4:21)23  3:38 PM      104680673 NotoSansCJK-OTC.zip
-a---          11/17/2023  3:38 PM      146751003 NotoSerifCJK-OTC.zip
Archive:  NotoSansCJK-OTC.zip
  inflating: C:\Windows\Fonts\/NotoSansCJK-Black.ttc  
  inflating: C:\Windows\Fonts\/NotoSansCJK-Regular.ttc  
  inflating: C:\Windows\Fonts\/NotoSansCJK-Bold.ttc  
  inflating: C:\Windows\Fonts\/NotoSansCJK-DemiLight.ttc  
  inflating: C:\Windows\Fonts\/NotoSansCJK-Light.ttc  
  inflating: C:\Windows\Fonts\/NotoSansCJK-Medium.ttc  
  inflating: C:\Windows\Fonts\/NotoSansCJK-Thin.ttc  
caution: filename not matched:  NotoSerifCJK-OTC.zip

Error: Process completed with exit code 1.
```

While it worked fine before introducing `teatimeguest/setup-texlive-action@v3` (https://github.com/muzimuzhi/ctex-kit/commit/38a56bc877f82a4bada0644ac3660976125ebf2a), see https://github.com/muzimuzhi/ctex-kit/actions/runs/6824782259.