### PR TITLE
Test tcolorbox 6.2.0 with LaTeX 2022-11-01

### DIFF
--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -79,6 +79,12 @@ jobs:
             done
           done
 
+      - name: Debug with tmate
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+
       - name: Archive
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -74,7 +74,6 @@ jobs:
               $engine \
                 -interaction=nonstopmode \
                 -jobname="${file/%.tex}"-"${engine/la/}" \
-                # required by tcolorbox library "minted"
                 -shell-escape \
                 "$file"
             done

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run example(s)
         working-directory: latex-examples
         run: |
-          export TEXMFHOME="$(realpath ./tcolorbox)"
+          export TEXMFHOME="$(realpath ../tcolorbox)"
           for file in *.tex; do
             for engine in pdflatex lualatex xelatex; do
               echo -e "\n\n"
@@ -74,6 +74,8 @@ jobs:
               $engine \
                 -interaction=nonstopmode \
                 -jobname="${file/%.tex}"-"${engine/la/}" \
+                # required by tcolorbox library "minted"
+                -shell-escape \
                 "$file"
             done
           done

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -20,7 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # https://gitlab.com/islandoftex/images/texlive
-      image: registry.gitlab.com/islandoftex/images/texlive:latest
+      # LaTeX 2021-11-15 was released and added to texlive's SVN on 11-12,
+      # so I'm guessing the image 2021-11-14 might be enough
+      # https://gitlab.com/islandoftex/images/texlive/container_registry/573747?orderBy=NAME&sort=asc&search[]=TL2021-2021-11&search[]=
+      image: registry.gitlab.com/islandoftex/images/texlive:TL2021-2021-11-14-04-43
     defaults:
       run:
         # The default shell for run steps inside a container is sh instead of bash.
@@ -28,10 +31,6 @@ jobs:
         shell: bash
 
     steps:
-      - name: Update TeX Live
-        run: |
-          tlmgr update --self --all
-
       - name: Globally opt-out Git security check
         run: |
           git config --global safe.directory "*"
@@ -49,6 +48,11 @@ jobs:
         run: |
           for file in *.tex; do
             for engine in pdflatex lualatex xelatex; do
+              echo "\n\n"
+              echo "========================"
+              echo "  $engine $file"
+              echo "========================"
+              echo "\n\n"
               # e.g., executes "pdflatex -jobname=simple-pdftex" simple.tex
               $engine -jobname="${file/%.tex}"-"${engine/la/}" "$file"
             done

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # https://gitlab.com/islandoftex/images/texlive
-      
+
       # LaTeX 2021-11-15 was released and added to texlive's SVN on 11-12,
       # so I'm guessing the image 2021-11-14 might be enough
       # - latex2e release
@@ -44,6 +44,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout tcolorbox@v6.2.0
+        uses: actions/checkout@v4
+        with:
+          repository: T-F-S/tcolorbox
+          ref: v6.2.0
+          token: ${{ github.token }}
+          path: tcolorbox
+          sparse-checkout: tex
+
       - name: Generate unique ID
         uses: ./.github/actions/unique-id
         with:
@@ -52,6 +61,7 @@ jobs:
       - name: Run example(s)
         working-directory: latex-examples
         run: |
+          export TEXMFHOME="$(realpath ./tcolorbox)"
           for file in *.tex; do
             for engine in pdflatex lualatex xelatex; do
               echo -e "\n\n"

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -20,9 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # https://gitlab.com/islandoftex/images/texlive
+      
       # LaTeX 2021-11-15 was released and added to texlive's SVN on 11-12,
       # so I'm guessing the image 2021-11-14 might be enough
-      # https://gitlab.com/islandoftex/images/texlive/container_registry/573747?orderBy=NAME&sort=asc&search[]=TL2021-2021-11&search[]=
+      # - latex2e release
+      #   https://github.com/latex3/latex2e/releases/tag/release-2021-11-15
+      # - texlive svn
+      #   https://www.tug.org/svn/texlive/trunk/Master/texmf-dist/doc/latex/base/README.md?r1=59599&r2=61041
+      # - islandoftex docker image
+      #   https://gitlab.com/islandoftex/images/texlive/container_registry/573747?orderBy=NAME&sort=asc&search[]=TL2021-2021-11&search[]=
       image: registry.gitlab.com/islandoftex/images/texlive:TL2021-2021-11-14-04-43
     defaults:
       run:
@@ -48,13 +54,17 @@ jobs:
         run: |
           for file in *.tex; do
             for engine in pdflatex lualatex xelatex; do
-              echo "\n\n"
+              echo -e "\n\n"
               echo "========================"
               echo "  $engine $file"
               echo "========================"
-              echo "\n\n"
-              # e.g., executes "pdflatex -jobname=simple-pdftex" simple.tex
-              $engine -jobname="${file/%.tex}"-"${engine/la/}" "$file"
+              echo -e "\n\n"
+              # e.g., executes
+              #   pdflatex -interaction=nonstopmode -jobname="simple-pdftex" simple.tex
+              $engine \
+                -interaction=nonstopmode \
+                -jobname="${file/%.tex}"-"${engine/la/}" \
+                "$file"
             done
           done
 

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -53,15 +53,23 @@ jobs:
           path: tcolorbox
           sparse-checkout: tex
 
+      - name: Checkout tikzfill@1.0.1
+        uses: actions/checkout@v4
+        with:
+          repository: T-F-S/tikzfill
+          ref: v1.0.1
+          token: ${{ github.token }}
+          path: tikzfill
+
       - name: Generate unique ID
         uses: ./.github/actions/unique-id
         with:
           set-env-context: true
 
       - name: Run example(s)
-        working-directory: latex-examples
         run: |
-          export TEXMFHOME="$(realpath ../tcolorbox)"
+          export TEXMFHOME="$(realpath ./tcolorbox):$(realpath ./tikzfill)"
+          cd latex-examples
           for file in *.tex; do
             for engine in pdflatex lualatex xelatex; do
               echo -e "\n\n"

--- a/.github/workflows/latex-docker.yml
+++ b/.github/workflows/latex-docker.yml
@@ -21,15 +21,7 @@ jobs:
     container:
       # https://gitlab.com/islandoftex/images/texlive
 
-      # LaTeX 2021-11-15 was released and added to texlive's SVN on 11-12,
-      # so I'm guessing the image 2021-11-14 might be enough
-      # - latex2e release
-      #   https://github.com/latex3/latex2e/releases/tag/release-2021-11-15
-      # - texlive svn
-      #   https://www.tug.org/svn/texlive/trunk/Master/texmf-dist/doc/latex/base/README.md?r1=59599&r2=61041
-      # - islandoftex docker image
-      #   https://gitlab.com/islandoftex/images/texlive/container_registry/573747?orderBy=NAME&sort=asc&search[]=TL2021-2021-11&search[]=
-      image: registry.gitlab.com/islandoftex/images/texlive:TL2021-2021-11-14-04-43
+      image: registry.gitlab.com/islandoftex/images/texlive:TL2022-2022-11-06-full
     defaults:
       run:
         # The default shell for run steps inside a container is sh instead of bash.

--- a/.github/workflows/latex-native.yml
+++ b/.github/workflows/latex-native.yml
@@ -11,12 +11,12 @@ on:
     # https://yaml.org/spec/1.2.2/#692-node-anchors
     # https://yaml.org/spec/1.2.2/#71-alias-nodes
     paths:
-      - 'latex-examples'
+      # - 'latex-examples'
       - '.github/actions/unique-id'
       - '.github/workflows/latex-native.yml'
   pull_request:
     paths:
-      - 'latex-examples'
+      # - 'latex-examples'
       - '.github/actions/unique-id'
       - '.github/workflows/latex-native.yml'
   workflow_dispatch:

--- a/.github/workflows/latex-native.yml
+++ b/.github/workflows/latex-native.yml
@@ -27,6 +27,7 @@ defaults:
 
 jobs:
   run-on-native-os:
+    if: false
     strategy:
       matrix:
         # as of 2023-12-02, macos-latest still uses macos-12

--- a/latex-examples/simple.tex
+++ b/latex-examples/simple.tex
@@ -1,8 +1,10 @@
+\RequirePackage[enable-debug]{expl3}
 \ExplSyntaxOn
 \debug_on:n { check-declarations, check-expressions, deprecation }
 \cs_generate_variant:Nn \tl_set:Nn { Ne }
 \ExplSyntaxOff
 
+\PassOptionsToPackage{draft}{minted}
 \documentclass{article}
 \usepackage[all]{tcolorbox}
 \listfiles

--- a/latex-examples/simple.tex
+++ b/latex-examples/simple.tex
@@ -1,4 +1,12 @@
+\ExplSyntaxOn
+\debug_on:n { check-declarations, check-expressions, deprecation }
+\cs_generate_variant:Nn \tl_set:Nn { Ne }
+\ExplSyntaxOff
+
 \documentclass{article}
+\usepackage[all]{tcolorbox}
+\listfiles
+
 \begin{document}
 content
 \end{document}


### PR DESCRIPTION
`https://github.com/T-F-S/tcolorbox/issues/267`

- https://github.com/T-F-S/tcolorbox/releases/tag/v6.2.0
- https://github.com/latex3/latex2e/releases/tag/release-2022-11-01
- https://github.com/latex3/latex2e/releases/tag/release-2022-11-01-PL1

Having no idea why LaTeX 2021-11-15, instead of 2022-11-01 was tested with at first.