### PR TITLE
Why `zauguin/install-texlive@v3` in `cache.yml` didn't install any packages

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -1,0 +1,4 @@
+latex-bin
+tex
+amsmath
+tools

--- a/.github/workflows/latex-zauguin.yml
+++ b/.github/workflows/latex-zauguin.yml
@@ -1,0 +1,20 @@
+name: Keep TeX Live cache up-to-date
+on:
+  # schedule:
+  #   # Run every tuesday and saturday at 02:48. The time has been chosen at random.
+  #   - cron: '48 2 * * 2,6'
+  push:
+    branches-ignore:
+      - '**/self'
+  workflow_dispatch:
+
+# copied from https://github.com/latex3/latex3/blob/main/.github/workflows/cache.yaml
+jobs:
+  cache:
+    runs-on: ubuntu-20.04
+    name: Update TeX Live
+    steps:
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v3
+        with:
+          package_file: .github/tl_packages

--- a/.github/workflows/latex-zauguin.yml
+++ b/.github/workflows/latex-zauguin.yml
@@ -5,7 +5,8 @@ on:
   #   - cron: '48 2 * * 2,6'
   push:
     branches-ignore:
-      - '**/self'
+      - 'self/**'
+  pull_request:
   workflow_dispatch:
 
 # copied from https://github.com/latex3/latex3/blob/main/.github/workflows/cache.yaml

--- a/.github/workflows/latex-zauguin.yml
+++ b/.github/workflows/latex-zauguin.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: Update TeX Live
     steps:
+      - name: Checkout repo to get tl_packages
+        uses: actions/checkout@v4
+
       - name: Install TeX Live
         uses: zauguin/install-texlive@v3
         with:


### PR DESCRIPTION
Find why the texlive cache created by [`cache.yml`](https://github.com/latex3/latex3/blob/main/.github/workflows/cache.yaml) in `latex3/latex3` is only ~4M large, while the cache created by [`main.yml`](https://github.com/latex3/latex3/blob/main/.github/workflows/main.yaml) in the same repo has size of ~110M.

From a sample workflow run, https://github.com/latex3/latex3/actions/runs/7938836038/job/21678171181, the cache restoration step in `zauguin/install-texlive@v3` acted as if `hashFiles(inputs.package_file)` returned empty.
```
Run actions/cache/restore@v4
  with:
    path: ~/texlive
    key: texlive-0--68b329da9893e34099c7d8ad5cb9c940-2024-02-17
    restore-keys: texlive-0--68b329da9893e34099c7d8ad5cb9c940-
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
```

https://github.com/zauguin/install-texlive/blob/main/action.yml
```yaml
    - name: Load cache
      id: load-cache
      uses: actions/cache/restore@v4
      with:
        path: ~/texlive
        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ steps.key-parts.outputs.packages-hash }}-${{ steps.key-parts.outputs.date }}
        restore-keys: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ steps.key-parts.outputs.packages-hash }}-
```