### PR TITLE
Add temp workflow to test cli/cli#5268

### DIFF
--- a/.github/workflows/tmp.yml
+++ b/.github/workflows/tmp.yml
@@ -1,10 +1,10 @@
 name: Test cli/cli#5268
 
 on:
-  push:
+  # push:
   #   paths:
   #     - '.github/workflows/test-github-actions.yml'
-  # pull_request:
+  pull_request:
   #   branches-ignore:
   #     - 'self/**' # "**" also matches remaining "/"
   #   paths:

--- a/.github/workflows/tmp.yml
+++ b/.github/workflows/tmp.yml
@@ -9,9 +9,9 @@ on:
   #     - 'self/**' # "**" also matches remaining "/"
   #   paths:
   #     - '.github/workflows/test-github-actions.yml'
-  #   types:
-  #     # added type of activity "ready_for_review"
-  #     [opened, ready_for_review, reopened, synchronize]
+    types:
+      # added type of activity "ready_for_review"
+      [opened, ready_for_review, reopened, synchronize]
   workflow_dispatch:
     inputs:
       timeout-minutes:

--- a/.github/workflows/tmp.yml
+++ b/.github/workflows/tmp.yml
@@ -1,0 +1,43 @@
+name: Test cli/cli#5268
+
+on:
+  # push:
+  #   paths:
+  #     - '.github/workflows/test-github-actions.yml'
+  # pull_request:
+  #   branches-ignore:
+  #     - 'self/**' # "**" also matches remaining "/"
+  #   paths:
+  #     - '.github/workflows/test-github-actions.yml'
+  #   types:
+  #     # added type of activity "ready_for_review"
+  #     [opened, ready_for_review, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      timeout-minutes:
+        description: Max time of the tmate step
+        required: false
+        # Max time of a job is 6h
+        # https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
+        default: 120
+        type: number
+      runner:
+        description: Name of runner image
+        required: false
+        # full list of GitHub-hosted runners
+        #     https://github.com/actions/runner-images
+        default: ubuntu-latest
+        type: string
+
+jobs:
+  test:
+    name: Hello
+
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run dummy commands
+        run: |
+          echo "Hello GitHub Actions"

--- a/.github/workflows/tmp.yml
+++ b/.github/workflows/tmp.yml
@@ -1,7 +1,7 @@
 name: Test cli/cli#5268
 
 on:
-  # push:
+  push:
   #   paths:
   #     - '.github/workflows/test-github-actions.yml'
   # pull_request:


### PR DESCRIPTION
```
https://github.com/cli/cli/issues/5268
```

What reported is, a new workflow (using `on.workflow_dispatch` only) committed to a non-default branch cannot be triggered by `workflow_dispatch` event, and is even not in the workflow list.

The doc of `on.workflow_dispatch` says

> This trigger only receives events when the workflow file is on the default branch.

- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch