### PR TITLE
Test job without `steps`

### DIFF
--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -2,57 +2,14 @@ name: Test GitHub Actions
 
 on:
   push:
-    paths:
-      - '.github/workflows/test-github-actions.yml'
-  pull_request:
-    branches-ignore:
-      - 'self/**' # "**" also matches remaining "/"
-    paths:
-      - '.github/workflows/test-github-actions.yml'
-    types:
-      # added type of activity "ready_for_review"
-      [opened, ready_for_review, reopened, synchronize]
   workflow_dispatch:
-    inputs:
-      timeout-minutes:
-        description: Max time of the tmate step
-        required: false
-        # Max time of a job is 6h
-        # https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
-        default: 120
-        type: number
-      runner:
-        description: Name of runner image
-        required: false
-        # full list of GitHub-hosted runners
-        #     https://github.com/actions/runner-images
-        # Defaults to macos-13, not macos-14 because the latter runs on Arm64
-        # architecture, which might behave differently than my X64 one.
-        default: macos-13
-        type: string
+
+# test if jobs.<job_id>.steps is required for normal jobs (jobs that don't call
+# reusable workflows)
+# https://github.com/github/vscode-github-actions/issues/291
+#
+# doc https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps
+
 jobs:
-  test:
-    name: Hello
-
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run dummy commands
-        run: |
-          echo "Hello GitHub Actions"
-
-      # run `touch continue` in GITHUB_WORKSPACE to continue
-      # https://github.com/mxschmitt/action-tmate/tree/v3/?tab=readme-ov-file#continue-a-workflow
-      - name: Setup tmate session
-        if: ${{ github.event_name == 'workflow_dispatch' || failure() }}
-        # `inputs` object exists => `inputs` is coerced to `true`;
-        #              otherwise => `inputs` is `null` thus coerced to `false`
-        # Moreover, `inputs` alone used in conditional is equivalent to
-        #     github.event_name == 'workflow_call' ||
-        #       github.event_name == 'workflow_dispatch'
-        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/expressions#literals
-        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#inputs-context
-        timeout-minutes: ${{ inputs && fromJson(inputs.timeout-minutes) || 15 }}
-        uses: mxschmitt/action-tmate@v3
+  no-steps:
+    runs-on: ubuntu-latest


### PR DESCRIPTION
```
https://github.com/github/vscode-github-actions/issues/291
```

Is [`jobs.<job_id>.steps`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) required in a job, unless the job calls a reusable workflow?

```yaml
on:
  push

jobs:
  # is jobs.<job_id>.steps is _required_ in normal jobs?
  normal-job-valid:
    runs-on: ubuntu-latest
    steps:
      - run: echo Hello World
  normal-job-invalid:
    # error expected or not?
    runs-on: ubuntu-latest

  # jobs.<job_id>.steps is forbidden in jobs that call reusable workflows
  # 
  call-reusable-workflow-valid:
    uses: ./path/to/workflow.yml
  call-reusable-workflow-invalid:
    uses: ./path/to/workflow.yml
    # error expected and does raised by vscode-github-actions, "Unexpected value 'steps'"
    steps:
      - run: echo Hello World
```

- Supported keywords for jobs that call a reusable workflow
  https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow
- The answer given by `actionlink` is "Yes". [live example](https://rhysd.github.io/actionlint/#eJyNUrFOAzEM3fsVVjt0IZf9hJhZgAXEiHIXtwnk4iN2KP17kqt6agUUlii2n59f/EKxXQCMmd1i8Uod12gF9dZcl/PF25uGBUcGz5DwPfuEFnyESGkwYUKWlkOkSqQ+TPC20gCkHFlRbCF3OUpWwQiyTKWJ84ACUBXZAvaO4BZDIHimFOw5r48nzCvAlCgBfo7YS1HUZYH7h0dIxjPaK+hNhA5heeeZfdxC6c0I62nsegmllemSxktr2FDqvLUY6x4qBsQZKSNDKCvKbLqAsKP0tgm044nJiZTnam2p52brxeWu6WnQGLXpxVNkzc6kolSZLDSYQ66y1dxMtuI8jpTKi9Ub7kvasipy6oJYVRWqqlBGHXXMrUXGVPpWODUsM3ILjR6NOC2kj5hmP4TfCc6c+YPiB+tMtGC9na1bPsW5dm7bv3/OF5jl9jo=)