### PR TITLE
Show that `working-directory` is never logged

### DIFF
--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -1,35 +1,12 @@
-name: Test GitHub Actions
-
-on:
-  push:
+on: [push]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      MY_VAR: GitHub
     steps:
-      - run: pwd && mkdir -p temp && ls .
-      - run: pwd && ls .
+      - run: mkdir -p temp
+      - run: echo "hello world"
+      - run: echo "hello $MY_VAR"
         working-directory: temp
-      - uses: actions/checkout@v4
-        with:
-          ## `clean: false` is usually ignoed. For the case here, it's because
-          ## of the lacking of pre-existing `.git` dir located in `path` input.
-          ## see https://github.com/actions/checkout/pull/561
-          ## Choosing a new sub-dir in ${{ github.workspace}} is a workaround.
-          # clean: false
-          path: repo
-      - run: pwd && ls .
-      - run: pwd && ls .
-        working-directory: repo/latex-examples
-
-      # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps
-      - name: All properties of a run step
-        if: true
-        id: step-prop
-        run: echo "hello $MY_VAR"
-        shell: bash
-        working-directory: temp
-        env:
-          MY_VAR: world
-        continue-on-error: false
-        timeout-minutes: 5

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -3,13 +3,13 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      MY_VAR: GitHub
     steps:
       - run: mkdir -p temp
       - name: Default shell and working-directory
         run: echo "hello world"
-      - name: Custom shell and working-directory
+      - name: Custom shell, working-directory, and env
         run: echo "hello $MY_VAR"
         shell: bash
         working-directory: temp
+        env:
+          MY_VAR: "world"

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -12,10 +12,15 @@ jobs:
         working-directory: temp
       - uses: actions/checkout@v4
         with:
-          clean: false
+          ## `clean: false` is usually ignoed. For the case here, it's because
+          ## of the lacking of pre-existing `.git` dir located in `path` input.
+          ## see https://github.com/actions/checkout/pull/561
+          ## Choosing a new sub-dir in ${{ github.workspace}} is a workaround.
+          # clean: false
+          path: repo
       - run: pwd && ls .
       - run: pwd && ls .
-        working-directory: latex-examples
+        working-directory: repo/latex-examples
 
       # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps
       - name: All properties of a run step

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -7,10 +7,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - run: pwd && mkdir -p temp
-      - run: pwd
+      - run: pwd && ls . && mkdir -p temp
+      - run: pwd && ls .
         working-directory: temp
       - uses: actions/checkout@v4
-      - run: pwd
-      - run: pwd
+      - run: pwd && ls .
+      - run: pwd && ls .
         working-directory: latex-examples

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -14,3 +14,15 @@ jobs:
       - run: pwd && ls .
       - run: pwd && ls .
         working-directory: latex-examples
+
+      # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps
+      - name: All properties of a run step
+        if: true
+        id: step-prop
+        run: echo "hello $MY_VAR"
+        shell: bash
+        working-directory: temp
+        env:
+          MY_VAR: world
+        continue-on-error: false
+        timeout-minutes: 5

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -7,10 +7,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - run: pwd && ls . && mkdir -p temp
+      - run: pwd && mkdir -p temp && ls .
       - run: pwd && ls .
         working-directory: temp
       - uses: actions/checkout@v4
+        with:
+          clean: false
       - run: pwd && ls .
       - run: pwd && ls .
         working-directory: latex-examples

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -7,6 +7,9 @@ jobs:
       MY_VAR: GitHub
     steps:
       - run: mkdir -p temp
-      - run: echo "hello world"
-      - run: echo "hello $MY_VAR"
+      - name: Default shell and working-directory
+        run: echo "hello world"
+      - name: Custom shell and working-directory
+        run: echo "hello $MY_VAR"
+        shell: bash
         working-directory: temp

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -2,57 +2,11 @@ name: Test GitHub Actions
 
 on:
   push:
-    paths:
-      - '.github/workflows/test-github-actions.yml'
-  pull_request:
-    branches-ignore:
-      - 'self/**' # "**" also matches remaining "/"
-    paths:
-      - '.github/workflows/test-github-actions.yml'
-    types:
-      # added type of activity "ready_for_review"
-      [opened, ready_for_review, reopened, synchronize]
-  workflow_dispatch:
-    inputs:
-      timeout-minutes:
-        description: Max time of the tmate step
-        required: false
-        # Max time of a job is 6h
-        # https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
-        default: 120
-        type: number
-      runner:
-        description: Name of runner image
-        required: false
-        # full list of GitHub-hosted runners
-        #     https://github.com/actions/runner-images
-        # Defaults to macos-13, not macos-14 because the latter runs on Arm64
-        # architecture, which might behave differently than my X64 one.
-        default: macos-13
-        type: string
+
 jobs:
   test:
-    name: Hello
-
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Run dummy commands
-        run: |
-          echo "Hello GitHub Actions"
-
-      # run `touch continue` in GITHUB_WORKSPACE to continue
-      # https://github.com/mxschmitt/action-tmate/tree/v3/?tab=readme-ov-file#continue-a-workflow
-      - name: Setup tmate session
-        if: ${{ github.event_name == 'workflow_dispatch' || failure() }}
-        # `inputs` object exists => `inputs` is coerced to `true`;
-        #              otherwise => `inputs` is `null` thus coerced to `false`
-        # Moreover, `inputs` alone used in conditional is equivalent to
-        #     github.event_name == 'workflow_call' ||
-        #       github.event_name == 'workflow_dispatch'
-        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/expressions#literals
-        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#inputs-context
-        timeout-minutes: ${{ inputs && fromJson(inputs.timeout-minutes) || 15 }}
-        uses: mxschmitt/action-tmate@v3
+      - run: mkdir -p temp
+      - run: ls .
+        working-directory: temp

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -7,6 +7,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - run: mkdir -p temp
-      - run: ls .
+      - run: pwd && mkdir -p temp
+      - run: pwd
         working-directory: temp
+      - uses: actions/checkout@v4
+      - run: pwd
+      - run: pwd
+        working-directory: latex-examples


### PR DESCRIPTION
Even when [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) is enabled.

Submitted feedback: https://github.com/orgs/community/discussions/138657