### PR TITLE
Test availability of `github.ref` in `pull_request_target` event

### DIFF
--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -8,9 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Is github.ref availabe in pull_request_target event?
+      - name: Selected "github" properties
         run: |
-          echo "\"github.ref\": >>${{ github.ref }}<<"
-          echo ""
-          echo "\"github\" object"
-          jq --null-input '${{ toJSON(github) }}'
+          jq --null-input '${{ toJSON(github) }} | pick(.ref, .base_ref, .head_ref)'
+      - name: Full "github" object
+        run: jq --null-input '${{ toJSON(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -1,58 +1,16 @@
 name: Test GitHub Actions
 
 on:
-  push:
-    paths:
-      - '.github/workflows/test-github-actions.yml'
-  pull_request:
-    branches-ignore:
-      - 'self/**' # "**" also matches remaining "/"
-    paths:
-      - '.github/workflows/test-github-actions.yml'
-    types:
-      # added type of activity "ready_for_review"
-      [opened, ready_for_review, reopened, synchronize]
-  workflow_dispatch:
-    inputs:
-      timeout-minutes:
-        description: Max time of the tmate step
-        required: false
-        # Max time of a job is 6h
-        # https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
-        default: 120
-        type: number
-      runner:
-        description: Name of runner image
-        required: false
-        # full list of GitHub-hosted runners
-        #     https://github.com/actions/runner-images
-        # Defaults to macos-13, not macos-14 because the latter runs on Arm64
-        # architecture, which might behave differently than my X64 one.
-        default: macos-13
-        type: string
+  # runs in the base branch, rather than the merge commit as for pull_request event
+  pull_request_target:
+
 jobs:
   test:
-    name: Hello
-
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Run dummy commands
+      - name: Is github.ref availabe in pull_request_target event?
         run: |
-          echo "Hello GitHub Actions"
-
-      # run `touch continue` in GITHUB_WORKSPACE to continue
-      # https://github.com/mxschmitt/action-tmate/tree/v3/?tab=readme-ov-file#continue-a-workflow
-      - name: Setup tmate session
-        if: ${{ github.event_name == 'workflow_dispatch' || failure() }}
-        # `inputs` object exists => `inputs` is coerced to `true`;
-        #              otherwise => `inputs` is `null` thus coerced to `false`
-        # Moreover, `inputs` alone used in conditional is equivalent to
-        #     github.event_name == 'workflow_call' ||
-        #       github.event_name == 'workflow_dispatch'
-        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/expressions#literals
-        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#inputs-context
-        timeout-minutes: ${{ inputs && fromJson(inputs.timeout-minutes) || 15 }}
-        uses: mxschmitt/action-tmate@v3
+          echo "\"github.ref\": >>${{ github.ref }}<<"
+          echo ""
+          echo "\"github\" object"
+          jq --null-input '${{ fromJson(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -1,7 +1,9 @@
 name: Test GitHub Actions
 
 on:
-  # runs in the base branch, rather than the merge commit as for pull_request event
+  # pull_request_target runs in the base branch, rather than the merge commit
+  # as for pull_request event. Thus to trigger a pull_Request_target event, it
+  # must already exist on the base branch.
   [pull_request, pull_request_target]
 
 jobs:
@@ -10,9 +12,6 @@ jobs:
     steps:
       - name: Selected "github" properties
         run: |
-          echo "github.event_name: >>${{ github.event_name }}<<"
-          echo "github.ref:        >>${{ github.ref }}<<"
-          echo "github.base_ref:   >>${{ github.base_ref }}<<"
-          echo "github.head_ref:   >>${{ github.head_ref }}<<"
+          jq --null-input '${{ toJSON(github) }} | pick(.event_name, .ref, .base_ref, .head_ref)'
       - name: Full "github" object
         run: jq --null-input '${{ toJSON(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
       - name: Selected "github" properties
         run: |
-          echo "github.ref:      >>${{ github.ref }}<<"
-          echo "github.base_ref: >>${{ github.base_ref }}<<"
-          echo "github.head_ref: >>${{ github.head_ref }}<<"
+          echo "github.event_name: >>${{ github.event_name }}<<"
+          echo "github.ref:        >>${{ github.ref }}<<"
+          echo "github.base_ref:   >>${{ github.base_ref }}<<"
+          echo "github.head_ref:   >>${{ github.head_ref }}<<"
       - name: Full "github" object
         run: jq --null-input '${{ toJSON(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - name: Selected "github" properties
         run: |
-          jq --null-input '${{ toJSON(github) }} | pick(.event_name, .ref, .base_ref, .head_ref)'
+          jq --null-input '${{ toJSON(github) }} | { event_name, ref, base_ref, head_ref}'
       - name: Full "github" object
         run: jq --null-input '${{ toJSON(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -2,7 +2,7 @@ name: Test GitHub Actions
 
 on:
   # runs in the base branch, rather than the merge commit as for pull_request event
-  pull_request_target:
+  [pull_request_target]
 
 jobs:
   test:

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Selected "github" properties
         run: |
-          jq --null-input '${{ toJSON(github) }} | pick(.ref, .base_ref, .head_ref)'
+          echo "github.ref:      >>${{ github.ref }}<<"
+          echo "github.base_ref: >>${{ github.base_ref }}<<"
+          echo "github.head_ref: >>${{ github.head_ref }}<<"
       - name: Full "github" object
         run: jq --null-input '${{ toJSON(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -13,4 +13,4 @@ jobs:
           echo "\"github.ref\": >>${{ github.ref }}<<"
           echo ""
           echo "\"github\" object"
-          jq --null-input '${{ fromJson(github) }}'
+          jq --null-input '${{ toJSON(github) }}'

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -2,7 +2,7 @@ name: Test GitHub Actions
 
 on:
   # runs in the base branch, rather than the merge commit as for pull_request event
-  [pull_request_target]
+  [pull_request, pull_request_target]
 
 jobs:
   test:


### PR DESCRIPTION
Inspired by
```
https://github.com/github/docs/issues/5457
https://github.com/github/docs/pull/5392
```
which added to the github docs that `github.base_ref` and `github.head_ref` are available for `pull_request_target` event.

Searching for `pull_request` in the [contexts doc page](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) reveals that `github.ref` is another property which is only documented for `pull_request` but not `..._target`.

- `pull_request_target` event
  https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
- `pull_request` webhook event payload (shared by both `pull_request` and `pull_request_target` events)
  https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request
- `github.ref` context property
  https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context