### PR TITLE
Test availability of `github.ref` in `pull_request_target` event, continued

### DIFF
--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Triggered by \"${{ github.event_name }}\" event
     runs-on: ubuntu-latest
     steps:
       - name: Selected "github" properties


### PR DESCRIPTION
Previous episode: #37

Now `on.pull_request_target` exists on the base branch, hence can be triggered.