### PR TITLE
Verify: does runner label `macos-14.0` exist?

### DIFF
--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -32,9 +32,7 @@ on:
         type: string
 jobs:
   test:
-    name: Hello
-
-    runs-on: ${{ inputs.runner || 'macos-old' }}
+    runs-on: macos-old
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -34,7 +34,7 @@ jobs:
   test:
     name: Hello
 
-    runs-on: ${{ inputs.runner || 'macos-14.0' }}
+    runs-on: ${{ inputs.runner || 'macos-old' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -34,7 +34,7 @@ jobs:
   test:
     name: Hello
 
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'macos-14.0' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
saw in `rhysd/actionlint`
https://github.com/rhysd/actionlint/blob/987484bb2048d952d5cde91dc16a19824e09cb95/rule_runner_label.go#L50