### PR TITLE
test: mise tool `typos`

### DIFF
--- a/.github/workflows/mise-action.yml
+++ b/.github/workflows/mise-action.yml
@@ -10,13 +10,14 @@ jobs:
   typos:
     runs-on: ubuntu-latest
 
+    env:
+      MISE_ENV: ci
+
     steps:
     - uses: actions/checkout@v7
 
     - name: Setup mise
       uses: jdx/mise-action@v4
-      env:
-        MISE_ENV: ci
 
     - name: Check mise tool
       run: |

--- a/.github/workflows/mise-action.yml
+++ b/.github/workflows/mise-action.yml
@@ -15,6 +15,8 @@ jobs:
 
     - name: Setup mise
       uses: jdx/mise-action@v4
+      env:
+        MISE_ENV: ci
 
     - name: Check mise tool
       run: |

--- a/.github/workflows/mise-action.yml
+++ b/.github/workflows/mise-action.yml
@@ -15,9 +15,6 @@ jobs:
 
     - name: Setup mise
       uses: jdx/mise-action@v4
-      with:
-        tool_versions: |
-          typos: latest
 
     - name: Check mise tool
       run: |
@@ -25,9 +22,4 @@ jobs:
 
     - name: Run mise tasks
       run: |
-        cat <<'EOF' >mise.toml
-        [tasks."lint:typos"]
-        run = "typos"
-        EOF
-
         mise run lint:typos

--- a/.github/workflows/mise-action.yml
+++ b/.github/workflows/mise-action.yml
@@ -1,0 +1,33 @@
+name: Test mise-action
+
+permissions:
+  contents: read
+
+on:
+  push:
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup mise
+      uses: jdx/mise-action@v4
+      with:
+        tool_versions: |
+          typos: latest
+
+    - name: Check mise tool
+      run: |
+        typos --version
+
+    - name: Run mise tasks
+      run: |
+        cat <<'EOF' >mise.toml
+        [tasks."lint:typos"]
+        run = "typos"
+        EOF
+
+        mise run lint:typos

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,0 +1,2 @@
+[tools]
+typos = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+typos = "latest"
+
+[tasks."lint:typos"]
+run = "typos"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,2 @@
-[tools]
-typos = "latest"
-
 [tasks."lint:typos"]
 run = "typos"


### PR DESCRIPTION
To dig https://github.com/muzimuzhi/latex-zutil/actions/runs/29311103382/job/87017807578

```
Run mise run lint:typos
  mise run lint:typos
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
    MISE_LOG_LEVEL: info
    MISE_GITHUB_TOKEN: ***
    MISE_TRUSTED_CONFIG_PATHS: /home/runner/work/latex-zutil/latex-zutil
    MISE_YES: 1
    PATH: /home/runner/.local/share/mise/installs/ruff/latest/ruff-x86_64-unknown-linux-musl:/home/runner/.local/share/mise/installs/tombi/latest/tombi-cli-1.2.0-x86_64-unknown-linux-musl:/home/runner/.local/share/mise/installs/typos/latest:/home/runner/.local/share/mise/shims:/home/runner/.local/share/mise/bin:/home/runner/work/_temp/uv-python-dir:/opt/hostedtoolcache/uv/0.11.28/x86_64:/home/runner/.local/bin:/home/runner/work/_temp/setup-texlive-action/2026/bin/x86_64-linux:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
[lint:typos] $ typos --config=config/typos.toml
[lint:typos] mise ERROR No version is set for shim: typos
[lint:typos] Set a global default version with one of the following:
[lint:typos] mise use -g typos@1.48.0
[lint:typos] mise ERROR Version: 2026.7.5 linux-x64 (2026-07-09)
[lint:typos] mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
[lint:typos] ERROR task failed
Error: Process completed with exit code 1.
```